### PR TITLE
pypi workflow with trusted publishing

### DIFF
--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -1,30 +1,23 @@
 name: Publish to PyPI
-run-name: Publish to ${{inputs.ENVIRONMENT=='testpypi' && 'Test' || ''}}PyPI ${{ inputs.REF && format('({0})', inputs.REF) }}
 
 on:
   push:
     tags:
-      - 'v[0-9].*' #pattern match
-  workflow_dispatch:
-    inputs:
-      REF:
-        type: string
-        description: Repository ref (tag/branch/SHA) to use. Use tags for uploading. (Defaults to the branch to use the workflow from)
-      BUILD_ONLY:
-        type: boolean
-        description: Build distributions without uploading.
-        default: false
-      ENVIRONMENT:
-        type: environment
-
+      - 'v[0-9]+.[0-9]+.[0-9]+' #pattern match
 
 jobs:
-  use-pypi_deploy-workflow:
-    uses: mctools/mctools_actions/.github/workflows/pypi_deploy.yml@main
-    with:
-      REPOSITORY: ${{ github.repository }}
-      REF: ${{ inputs.REF || github.ref_name }}
-      DO_DEPLOY: ${{ !inputs.BUILD_ONLY }}
-      ENVIRONMENT: ${{ inputs.ENVIRONMENT || 'pypi' }}
-    secrets:
-      PYPI_API_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
+  build_and_publish:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write # IMPORTANT: this permission is mandatory for trusted publishing
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Build distribution
+        run: |
+          python3 -m pip install build
+          python3 -mbuild
+
+      - name: Upload distribution to PyPI 
+        uses: pypa/gh-action-pypi-publish@v1.8.11


### PR DESCRIPTION
Simple workflow to publish new distribution to PyPI on pushed tags matching the format: 'v[0-9]+.[0-9]+.[0-9]+'