### PR TITLE
minor documentation related changes

### DIFF
--- a/doc/source/simplebuilddotcfg.rst
+++ b/doc/source/simplebuilddotcfg.rst
@@ -104,7 +104,7 @@ Information about which other bundles the current package bundle depends on.
   mechanism (see :ref:`below <sbpymodsearchpath>`). The ``core`` and
   ``core_val`` bundles are always available via this latter mechanism (the same
   goes for the ``dgcode`` and ``dgcode_val`` bundles, if the
-  ``simple-build-dgcode`` package has been installed).
+  ``simple-build-dgcode`` Python or Conda package has been installed).
 
 
 The ``[build]`` section
@@ -232,15 +232,16 @@ plugin
 mechanism. This is in fact how bundles like ``core`` and ``core_val`` are made
 easily available for all users without requiring them to edit their
 ``project.search_path`` (the same goes for the ``dgcode`` and ``dgcode_val``
-bundles, if the ``simple-build-dgcode`` package has been installed).
+bundles, if the ``simple-build-dgcode`` Python or Conda package has been
+installed).
 
 Specifically, simplebuild will look for Python modules whose names follow the
 pattern ``[_]simplebuild_[anything].simplebuild_bundle_list``. Inside that module
 there must be a function called ``simplebuild_bundle_list()`` which returns a
 list of pathlib.Path objects, each being an absolute path to a
 ``simplebuild.cfg`` file. As an example, installing the ``simple-build-dgcode``
-package, results in a new Python module becoming available in the environment:
-``simplebuild_dgcode.simplebuild_bundle_list``, with a
+Python or Conda package, results in a new Python module becoming available in
+the environment: ``simplebuild_dgcode.simplebuild_bundle_list``, with a
 ``simplebuild_bundle_list()`` returning the full path to two ``simplebuild.cfg``
 files: one for the ``dgcode`` bundle, and one for the ``dgcode_val`` bundle.
 

--- a/src/_simple_build_system/data/cfgtemplate.txt
+++ b/src/_simple_build_system/data/cfgtemplate.txt
@@ -16,14 +16,14 @@
   # If you wish to let other projects use your bundle of packages, you must give
   # it a name (so they can specify it in their list depend.projects list):
   #
-  #  name = 'myprojectname'
+  #   name = 'myprojectname'
   #
   # If the directory below which you keep your simplebuild packages (i.e. "the
   # package root") is not meant to be the same directory as the directory
   # containing this cfg-file, you can modify it here. If for instance, all the
   # packages are below a subdirectory called 'mypkgs', you could specify:
   #
-  # pkg_root = './mypkgs' #default is '.'
+  #   pkg_root = './mypkgs' #default is '.'
   #
 
 [depend]

--- a/src/_simple_build_system/parse_args.py
+++ b/src/_simple_build_system/parse_args.py
@@ -91,15 +91,15 @@ $> {_p} --init core_val dgcode COMPACT DEBUG
     group_build.add_argument(
         "-j", "--jobs",
         type=int, dest="njobs", default=0, metavar="N",
-        help="Use up to N parallel processes (default: auto)")
+        help="Use up to N parallel processes (default: auto).")
     group_build.add_argument(
         "-e", "--examine",
         action='store_true', dest="examine",
-        help="Force (re)examination of environment")
+        help="Force (re)examination of environment.")
     group_build.add_argument(
         "-i", "--insist",
         action="store_true", dest="insist",
-        help="Insist on reconf/rebuild/reinstall from scratch")
+        help="Insist on reconf/rebuild/reinstall from scratch.")
 
     group_query_g = parser.add_argument_group('Query options')
     group_query = group_query_g.add_mutually_exclusive_group()
@@ -116,7 +116,7 @@ $> {_p} --init core_val dgcode COMPACT DEBUG
 
     group_query.add_argument("--pkginfo",
                              action="store", dest="pkginfo", default='',metavar='PKG',
-                             help="Print information about package PKG")
+                             help="Print information about package PKG.")
     exclusive.add('pkginfo')
     group_query.add_argument("--incinfo",action="store", dest="incinfo",
                              default='',metavar='CFILE',
@@ -126,26 +126,26 @@ $> {_p} --init core_val dgcode COMPACT DEBUG
     exclusive.add('incinfo')
     group_query.add_argument("--pkggraph",
                              action="store_true", dest="pkggraph",
-                             help="Create graph of package dependencies")
+                             help="Create graph of package dependencies.")
     exclusive.add('pkggraph')
 
     group_query.add_argument("--activegraph",
                              action="store_true", dest="pkggraph_activeonly",
-                             help="Create graph for enabled packages only")
+                             help="Create graph for enabled packages only.")
     exclusive.add(('--activegraph','pkggraph_activeonly'))
 
     group_query.add_argument("--grep",action="store", dest="grep",
                              default='',metavar='PATTERN',
-                             help="Grep files in packages for PATTERN")
+                             help="Grep files in packages for PATTERN.")
     exclusive.add('grep')
     group_query.add_argument("--grepc",action="store", dest="grepc",
                              default='',metavar='PATTERN',
-                             help="Like --grep but show only count per package")
+                             help="Like --grep but show only count per package.")
     exclusive.add('grepc')
     group_query.add_argument("--find",action="store", dest="find",
                              default=None, metavar='PATTERN',
                              help=("Search for file and path names"
-                                   " matching PATTERN"))
+                                   " matching PATTERN."))
     exclusive.add('find')
 
     #NB: Do not change the title in title in the next line without updating its
@@ -160,7 +160,7 @@ $> {_p} --init core_val dgcode COMPACT DEBUG
 
     group_test.add_argument("-t", "--tests",
                            action="store_true", dest="runtests",
-                           help="Run unit tests after the build")
+                           help="Run unit tests after the build.")
     exclusive.add(('--tests','runtests'))
     group_test.add_argument("--testexcerpts", type=int, dest="nexcerpts",
                             default=0,metavar="N",
@@ -186,12 +186,12 @@ $> {_p} --init core_val dgcode COMPACT DEBUG
                              default=None, metavar='PATTERN',
                              help=("Global search and replace in packages via"
                                    " pattern\nlike '/OLDCONT/NEWCONT/' (use "
-                                   "with care!)"))
+                                   "with care!)."))
     exclusive.add('replace')
 
     group_other.add_argument("--removelock",
                            action='store_true', dest="removelock",
-                           help="Force removal of lockfile")
+                           help="Force removal of lockfile.")
 
     group_other.add_argument("--env-setup",
                              action="store_true", dest="env_setup",


### PR DESCRIPTION
- Clarify that 'simple-build-dgcode' is a Conda or Python package. 
- Unify cfgtemplate indentation.
- End all sb command help text with a dot. (Except the builtin --help, but otherwise it is uniform now.)